### PR TITLE
Update fbctl guide

### DIFF
--- a/docs/command-line-interface.md
+++ b/docs/command-line-interface.md
@@ -125,7 +125,6 @@ We estimate that redis process is <alive-redis-count>.
 - Conf file not exist
 
 Conf file is not found. To resove this error, use 'cluster configure' and then 'cluster start'.
-cluster configure 명령어를 실행시킨 후 cluster start를 진행하세요.
 
 ``` bash
 $ cluster start
@@ -140,7 +139,8 @@ For detail information, please check log files.
 ``` bash
 $ cluster start
 ...
-max try error
+ClusterRedisError: Fail to start redis: max try exceed
+Recommendation Command: 'monitor'
 ```
 
 **(3) cluster create**
@@ -740,7 +740,7 @@ No rows selected (0.55 seconds)
 
 Default value of db url to connect is jdbc:hive2://$HIVE_HOST:$HIVE_PORT
 
-You can modify $HIVE_HOST and $HIVE_PORT by command conf ths
+You can modify $HIVE_HOST and $HIVE_PORT by command 'conf ths'
 
 **(2) thriftserver monitor**
 
@@ -774,9 +774,7 @@ ec2-user@flashbase:1> thriftserver start
 starting org.apache.spark.sql.hive.thriftserver.HiveThriftServer2, logging to /opt/spark/logs/spark-ec2-user-org.apache.spark.sql.hive.thriftserver.HiveThriftServer2-1-ip-172-31-39-147.ap-northeast-2.compute.internal.out
 ```
 
-You can view the logs through the command 
-
-**monitor**.
+You can view the logs through the command 'monitor'.
 
 **(5) stop thriftserver**
 

--- a/docs/command-line-interface.md
+++ b/docs/command-line-interface.md
@@ -593,10 +593,6 @@ replicate [M] 127.0.0.1 18301 - [S] 127.0.0.1 18351
 replicate [M] 127.0.0.1 18302 - [S] 127.0.0.1 18352
 replicate [M] 127.0.0.1 18303 - [S] 127.0.0.1 18353
 replicate [M] 127.0.0.1 18304 - [S] 127.0.0.1 18354
-1 / 5 meet complete.
-2 / 5 meet complete.
-3 / 5 meet complete.
-4 / 5 meet complete.
 5 / 5 meet complete.
 ```
 

--- a/docs/install-fbctl.md
+++ b/docs/install-fbctl.md
@@ -96,15 +96,19 @@ Use below option not to save last used value.
 Select installer
 
     [ INSTALLER LIST ]
-    (1) flashbase.dev.master.dbcb9e.bin
-    (2) flashbase.trial.master.dbcb9e-dirty.bin
-    (3) flashbase.trial.master.dbcb9e.bin
+    (1) [DOWNLOAD] flashbase.dev.master.dbcb9e.bin
+    (2) [LOCAL] flashbase.dev.master.dbcb9e.bin
+    (3) [LOCAL] flashbase.trial.master.dbcb9e-dirty.bin
+    (4) [LOCAL] flashbase.trial.master.dbcb9e.bin
 
 Please enter the number, file path or url of the installer you want to use.
 you can also add file in list by copy to '$FBPATH/releases/'
 1
 OK, flashbase.dev.master.dbcb9e.bin
 ```
+!!! Tip
+    LOCAL means installer file under path '$FBPATH/releases/' on your local.
+    DOWNLOAD refers to a file that can be downloaded and up to 5 files are displayed in the latest order. To confirm the recommended FlashBase version, use [Release Notes](release-note.md)
 
 With only URL, instead of file path, LightningDB can be installed like below.
 

--- a/docs/install-fbctl.md
+++ b/docs/install-fbctl.md
@@ -30,7 +30,7 @@ $ fbctl
 
 When FBCTL starts at the first time,  you needs to confirm 'base_directory'.
 
-[~/tsr2][^1]] is default value.
+[~/tsr2][^1] is default value.
 
 ``` bash
 Type base directory of flashbase [~/tsr2]
@@ -81,7 +81,7 @@ After deploy command, you should type the following information that provides it
 - number of masters
 - replicas
 - number of ssd(disk)
-- prefix of (redis data / redis db path / flash db path)
+- prefix of db path (used for redis data /redis db path / flash db path )
 
 
 Use below option not to save last used value.

--- a/docs/install-fbctl.md
+++ b/docs/install-fbctl.md
@@ -110,9 +110,7 @@ OK, flashbase.dev.master.dbcb9e.bin
     LOCAL means installer file under path '$FBPATH/releases/' on your local.
     DOWNLOAD refers to a file that can be downloaded and up to 5 files are displayed in the latest order. To confirm the recommended FlashBase version, use [Release Notes](release-note.md)
 
-With only URL, instead of file path, LightningDB can be installed like below.
-
-To copy the link of the recommended FlashBase version, use [Release Notes](release-note.md).
+Select a number to use that file. Type DOWNLOAD will be used after downloading. The downloaded file is saved in path '$FBPATH/releases'.
 
 ``` bash
 Select installer
@@ -127,6 +125,9 @@ Downloading flashbase.dev.master.5a6a38.bin
 [==================================================] 100%
 OK, flashbase.dev.master.5a6a38.bin
 ```
+
+If installer list is empty like above, you can also use file path or url. If you enter url, download the file and use it. The downloaded file is saved in path '$FBPATH/releases'.
+
 
 **(2) Type Hosts**
 


### PR DESCRIPTION
오타 및 개선점들을 수정하였습니다.
검토 후 선택적으로 반영해주시면 될 것 같습니다.

fbctl v0.2.12 업데이트 사항 추가적으로 반영하였습니다.
- installer type (LOCAL / DOWNLOAD)
- add slave에서 cluster meet 로그 간소화